### PR TITLE
feat(backend): add /models api

### DIFF
--- a/backend/src/api/index.ts
+++ b/backend/src/api/index.ts
@@ -2,7 +2,8 @@ import { Elysia } from "elysia";
 import { completionsApi } from "./completions";
 import { usageQueryApi } from "./usage";
 import { routes as adminRoutes } from "./admin";
+import { modelsQueryApi } from "./models";
 
 export const routes = new Elysia()
-  .group("/v1", (app) => app.use(completionsApi))
+  .group("/v1", (app) => app.use(completionsApi)).use(modelsQueryApi)
   .group("/api", (app) => app.use(usageQueryApi).use(adminRoutes));

--- a/backend/src/api/models.ts
+++ b/backend/src/api/models.ts
@@ -1,0 +1,26 @@
+import { Elysia, t } from "elysia";
+
+import { apiKeyPlugin } from "../plugins/apiKeyPlugin";
+import { consola } from "consola";
+import { findApiKey, listUpstreams } from "@/db";
+
+const logger = consola.withTag("modelsQuery");
+
+export const modelsQueryApi = new Elysia()
+  .get(
+    "/models",
+    async ({ error }) => {
+      logger.debug("queryModels");
+      
+      const upstreams = await listUpstreams();
+      return {
+          object: "list",
+          data: upstreams.map(upstream => ({
+            id: upstream.id,
+            object: "model",
+            created: upstream.createdAt.getTime(),
+            owned_by: upstream.name,
+          })),
+        };
+    },
+  );

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "extends": ["backend/biome.json"],
+  "files": {
+    "ignore": ["frontend/**"]
+  }
+}


### PR DESCRIPTION
This pull request includes add /models api. It created `backend/src/api/models.ts` and added it to the `/v1` routes group.